### PR TITLE
Fix typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="simple.min.css">
 </head>
 <body>
-    <h1>oubhub.org retired</h1>
+    <h1>uobhub.org retired</h1>
 
     <p> We have retired the uobhub.org JupyterHub server.  If you are looking
     for your notebooks or R scripts from that system, we may still have them.


### PR DESCRIPTION
I noticed a typo in the header of your site, and thought I'd point it out.
Correcting typo "oubhub.org" to "uobhub.org" (line 12)